### PR TITLE
Change js to javascript in convert.py

### DIFF
--- a/multilingual/plbart/convert.py
+++ b/multilingual/plbart/convert.py
@@ -71,7 +71,7 @@ def sanity_check(model_name_or_path, checkpoint_file):
     assert bart.task.source_dictionary[50001] == '__java__'
     assert bart.task.source_dictionary[50002] == '__python__'
     assert bart.task.source_dictionary[50003] == '__en_XX__'
-    assert bart.task.source_dictionary[50004] == '__js__'
+    assert bart.task.source_dictionary[50004] == '__javascript__'
     assert bart.task.source_dictionary[50005] == '__php__'
     assert bart.task.source_dictionary[50006] == '__ruby__'
     assert bart.task.source_dictionary[50007] == '__go__'


### PR DESCRIPTION
The current script leads to an error:

```python
Traceback (most recent call last):
  File "convert.py", line 102, in <module>
    sanity_check(args.output_dir, args.output_ckpt)
  File "convert.py", line 75, in sanity_check
    assert bart.task.source_dictionary[50004] == '__js__'
AssertionError
```

Changing it to `__javascript__` fixes it.